### PR TITLE
add email, possible reciepients and domain to response

### DIFF
--- a/app.js
+++ b/app.js
@@ -57,10 +57,21 @@ app.post("/token/new", function* () {
 				    });				
 				}
 			    newToken = yield newToken.save();
-			    this.body={verified:true , message:"Thank you for adding your token!", token:newToken.attributes.token};
+			    this.body={
+			    	verified:true,
+			    	message:"Thank you for adding your token!",
+			    	token: newToken.attributes.token,
+			    	email: newToken.attributes.email,
+			    	possibleRecipients: verify.possibleRecipients,
+			    	domain: verify.domain
+			    };
 			}
 			else{
-				this.body={verified:false , message:"The token you entered was incorrect, please make sure you have entered the correct token", token:this.request.body.token};
+				this.body={
+					verified:false,
+					message:"The token you entered was incorrect, please make sure you have entered the correct token",
+					token: this.request.body.token
+				};
 			}
 			
 		}
@@ -74,15 +85,29 @@ app.post("/token/new", function* () {
 		 		var updateToken = yield new Token({id: token.attributes.id})
 			 		.save({token: this.request.body.token, phone:number, email:verify.email}, {patch: true});	
 		 		}
-					this.body={verified:true , message:"Thank you for adding your token!", token:updateToken.attributes.token};
+					this.body={
+						verified:true,
+						message:"Thank you for adding your token!",
+						token: updateToken.attributes.token,
+						email: updateToken.attributes.email,
+						possibleRecipients: verify.possibleRecipients,
+			    		domain: verify.domain
+					};
 			    }
 			else{
-				this.body={verified:false , message:"The token you entered was incorrect, please make sure you have entered the correct token", token:this.request.body.token};
+				this.body={
+					verified:false,
+					message:"The token you entered was incorrect, please make sure you have entered the correct token",
+					token:this.request.body.token
+				};
 			}
 		}
 	}
 	else{
-		this.body={verified:false , message:"You did not send a token, please try again"};
+		this.body={
+			verified:false,
+			message:"You did not send a token, please try again"
+		};
 	}
 
 })

--- a/token.js
+++ b/token.js
@@ -1,7 +1,26 @@
 var cheerio = require("cheerio");
 var request = require("request");
 var when = require("when");
+var parseEmailData = require("parseEmailData");
 var getURI = "https://www.tinypulse.com/user_portal/cheers/new?response_token=";
+
+var getEmailData = function(body) {
+	var scripts = body("script");
+	console.log(scripts.length);
+	var script = "";
+	scripts.each(function() {
+		var text = body(this).text();
+
+
+		if(text.indexOf(".cheers-autocomplete") != -1) {
+			script = text;
+		}
+	});
+
+	var emailData = parseEmailData(script);
+
+	return emailData;
+};
 
 module.exports = verifyToken = {
 
@@ -22,8 +41,13 @@ module.exports = verifyToken = {
 						return verifyReturn;
 					}
 					else{
-						var email = cheerioBody('p.active-account strong').text();
-						var verifyReturn = {verified: true, email:email};
+						var emailData = getEmailData(cheerioBody);
+						var verifyReturn = {
+							verified: true,
+							email: emailData.sender,
+							possibleRecipients: emailData.emails,
+							domain: emailData.domain 
+						};
 						resolve(verifyReturn);
 						return verifyReturn;
 					}


### PR DESCRIPTION
@conorhastings I haven't actually run this to test at all. But this should add email to the response (looks like it was only getting saved to the DB), as well as possible recipients, which will allow us to generate the tokenizer, and domain (which seemed useful? maybe?).
